### PR TITLE
feat: add raw loader rule

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -54,4 +54,8 @@
 		test: /\.(png|jpe?g|gif|svg|woff2?|eot|ttf)$/,
 		type: 'asset/inline',
 	},
+	RULE_RAW: {
+		resourceQuery: /raw/,
+		type: 'asset/source',
+	},
  }


### PR DESCRIPTION
Anything that builds `@nextcloud/dialogs` needs this

https://github.com/nextcloud-libraries/nextcloud-dialogs/blob/0a5e97166447f53aa5d28c582475705aa2c56768/lib/filepicker-builder.ts#L30-L31