### PR TITLE
fix: ignore `./locale` import from `moment/min/moment-with-locales`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -114,6 +114,15 @@ module.exports = {
 		// Make appName & appVersion available as a constant
 		new webpack.DefinePlugin({ appName: JSON.stringify(appName) }),
 		new webpack.DefinePlugin({ appVersion: JSON.stringify(appVersion) }),
+
+		// @nextcloud/moment since v1.3.0 uses `moment/min/moment-with-locales.js`
+		// Which works only in Node.js and is not compatible with Webpack bundling
+		// It has an unused function `localLocale` that requires locales by invalid relative path `./locale`
+		// Though it is not used, Webpack tries to resolve it with `require.context` and fails
+		new webpack.IgnorePlugin({
+			resourceRegExp: /^\.\/locale$/,
+			contextRegExp: /moment\/min$/,
+		}),
 	],
 
 	resolve: {


### PR DESCRIPTION
Fixes compatibility between `@nextcloud/webpack-vue-config` and `@nextcloud/moment@1.3.0` (since [migration to Vite](https://github.com/nextcloud-libraries/nextcloud-moment/pull/781)).

`@nextcloud/moment` uses `moment/min/moment-with-locales.js`, which works only in Node.js and is not compatible with Webpack bundling. It has an unused function `localLocale` that requires locales by invalid relative path `./locale`. Though it is not used, Webpack tries to resolve it with `require.context` and fails.

Example of issue in Talk, same in Text and other apps:
```
WARNING in ./spreed/node_modules/moment/min/moment-with-locales.js 2159:16-50
Module not found: Error: Can't resolve './locale' in '<...>\talk-desktop\spreed\node_modules\moment\min'
```

See also:
- Import in `@nextcloud/moment`: https://github.com/nextcloud-libraries/nextcloud-moment/blob/c73f43f7e7713a92bad98251aad22b3cd57a757e/lib/index.ts#L1
- `moment/min/moment-with-locales.js`: https://github.com/moment/moment/blob/develop/min/moment-with-locales.js#L2159
- https://webpack.js.org/plugins/ignore-plugin/ (even Webpack uses it as an example for Ignore plugin)