### PR TITLE
fix: make ignore plugin cross-platform

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,8 +120,8 @@ module.exports = {
 		// It has an unused function `localLocale` that requires locales by invalid relative path `./locale`
 		// Though it is not used, Webpack tries to resolve it with `require.context` and fails
 		new webpack.IgnorePlugin({
-			resourceRegExp: /^\.\/locale$/,
-			contextRegExp: /moment\/min$/,
+			resourceRegExp: /^\.[/\\]locale$/,
+			contextRegExp: /moment[/\\]min$/,
 		}),
 	],
 


### PR DESCRIPTION
- Make cross-platform config for https://github.com/nextcloud-libraries/webpack-vue-config/pull/533
- In some places, Webpack does not normalize slashes. On Windows, this path is `moment\min\locale` instead of `moment/min/locale` and RegExp didn't work.
- Used in Talk Desktop when packaging on Windows for Windows