### PR TITLE
refactor: remove unneeded NodePolyfillPlugin config after bump to v4

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,10 +106,7 @@ module.exports = {
 
 		// Make sure we auto-inject node polyfills on demand
 		// https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed
-		new NodePolyfillPlugin({
-			// Console is available in the web-browser
-			excludeAliases: ['console'],
-		}),
+		new NodePolyfillPlugin(),
 
 		// Make appName & appVersion available as a constant
 		new webpack.DefinePlugin({ appName: JSON.stringify(appName) }),


### PR DESCRIPTION
After upgrading to NodePolyFillPlugin v4 in https://github.com/nextcloud-libraries/webpack-vue-config/pull/580 `console` is now excluded by default