### PR TITLE
fix: include `process` Node polyfill

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,7 +89,9 @@ module.exports = {
 
 		// Make sure we auto-inject node polyfills on demand
 		// https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-nodejs-polyfills-removed
-		new NodePolyfillPlugin(),
+		new NodePolyfillPlugin({
+			additionalAliases: ['process'],
+		}),
 
 		// Make appName & appVersion available as a constant
 		new webpack.DefinePlugin({ appName: JSON.stringify(appName) }),


### PR DESCRIPTION
- Not included by default since `node-polyfill-webpack-plugin@4.0.0`
- Used by `path` module
- Which is used by `@nextcloud/dialogs`

Thanks @Antreesy for catching the issue.

This is probably not the root issue, because `path` alias doesn't use `process`... Only the original node module does. The problem for us is that somewhere `path` is not polyfilled. It may not work with `node:path` import, but we don't have any.

So, no idea why `path` is not polyfilled. But polifillying `process` solves the problem as well...

![image](https://github.com/user-attachments/assets/4f027500-b632-4bd8-8f1d-df54d477f3d5)
