### PR TITLE
chore: ignore test-apps in NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 tests
+test-apps
 .github


### PR DESCRIPTION
- A small regression from https://github.com/nextcloud-libraries/webpack-vue-config/pull/658
- I've added a new folder for test apps, but I forgot to ignore it in NPM
- Makes package 34kB instead of 140kB