### PR TITLE
fix: remove `vue$` alias to support dependencies with different Vue version

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,12 +109,5 @@ module.exports = {
 
 	resolve: {
 		extensions: ['*', '.ts', '.js', '.vue'],
-		symlinks: false,
-		// Ensure npm does not duplicate vue dependency, and that npm link works for vue 3
-		// See https://github.com/vuejs/core/issues/1503
-		// See https://github.com/nextcloud/nextcloud-vue/issues/3281
-		alias: {
-			'vue$': path.resolve('./node_modules/vue')
-		},
 	},
 }


### PR DESCRIPTION
- Ref: https://github.com/nextcloud-libraries/nextcloud-password-confirmation/pull/1000

Adding alias like `'vue$': path.resolve('./node_modules/vue')` breaks the expected module resolution.
Different dependencies may have different Vue versions, and this is fine.

This will lead to duplicate Vue dependency with `npm link` as said in the comment.

But `npm link` shouldn't be used in such scenarios (where dependency resolution is important). It acts very different from an actual installation:
- Only supports a single Vue version
- Doesn't cover other dependencies like `vue-router` or `@vueuse/core`
- Doesn't cover correct dependency resolution or other dependencies, overrides and etc.

Alternatives:
- `npm pack` + `npm install` for one time clean installation testing (without watch)
- Setting up monopero for a full-featured environment with all the dependencies for a good DX with watch mode